### PR TITLE
lib: handle JSON parse errors

### DIFF
--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -118,6 +118,9 @@ SendEmitter.prototype.attach = function (stream) {
 		ev.emit.apply(ev, args.args);
 	});
 
+	// Propagate parse errors to the SendEmitter object
+	this.parser.on('error', this.emit.bind(this, 'error'));
+
 	// Attach stream
 	this.stream = stream;
 

--- a/test/basics.js
+++ b/test/basics.js
@@ -1,4 +1,5 @@
 var Uhura = require('../');
+var assert = require('assert');
 
 function after (t, fn) {
 	return function () {
@@ -53,6 +54,14 @@ describe('basics', function () {
 		};
 		c.socket.emit('error', new Error('This is an error'));
 		s.socket.destroy();
+	});
+
+	it('should not crash on malformed JSON', function (next) {
+		s.on('error', function (err) {
+			assert(/Unexpected "." at position/.test(err.message));
+			next();
+		});
+		c.socket.write('.');
 	});
 
 	it('should send acknowledgements', function (next) {


### PR DESCRIPTION
Don't throw an uncatchable exception when the input is malformed JSON.
Forward the exception as an 'error' event that the user can handle or
ignore as s/he sees fit.

Suggested reviewers: @themitchy @Qard.  Without this patch it's dead simple to bring down the nodefly-collector (accidentally or otherwise.)
