### PR TITLE
lib/client: fix stalls with large payloads

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -85,7 +85,7 @@ Client.prototype.connect = function (port, host) {
 
 Client.prototype.disconnect = function () {
 	this._reconnect = false;
-	this.socket.destroy();
+	this.socket.destroySoon();
 };
 
 /**

--- a/test/basics.js
+++ b/test/basics.js
@@ -64,6 +64,14 @@ describe('basics', function () {
 		c.socket.write('.');
 	});
 
+	it('should flush on disconnect', function (next) {
+		s.once('ping', function () { next() });
+		c.once('connect', function () {
+			c.send('ping', Array(1 << 20).join('.'));
+			c.disconnect();
+		});
+	});
+
 	it('should send acknowledgements', function (next) {
 		c.send('ping', next);
 	});


### PR DESCRIPTION
Replace call to net.Socket#destroy() with net.Socket#destroySoon();
the former closes the connection immediately while the latter waits
until any pending writes have been written.

Point of action: calling send() + disconnect() before the 'connect'
event has been emitted still doesn't work.

Suggested reviewers: @Qard @themitchy
