### PR TITLE
lib/client: unref reconnect timer

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -87,7 +87,14 @@ Client.prototype.connect = function (options) {
 		if (ev._reconnect) {
 			var delay = Math.min(ev._retryTimeoutMax, Math.pow(ev._retryTimeout, ev._retries));
 			ev._retries++;
-			setTimeout(ev.reconnect.bind(ev), delay);
+			var timer = setTimeout(ev.reconnect.bind(ev), delay);
+			if (timer.unref) {
+				// FIXME(bnoordhuis) Unref'ing this timer is
+				// maybe not always the right thing to do but
+				// it fixes a stall on exit in strong-agent
+				// where this timer was the only handle left.
+				timer.unref();
+			}
 		}
 	});
 };


### PR DESCRIPTION
Unref the reconnect timer so it doesn't keep the event loop alive.
Fixes a stall at exit in strong-agent.

No regression test, I'm afraid.  The particular condition of whether
or not the event loop has cleaned out is pretty much impossible to
test with mocha.

Suggested reviewers: @themitchy @Qard
