### PR TITLE
Fixes for issue #11

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -162,7 +162,10 @@ function onConnection (err, socket) {
 	ev.attach(socket);
 
 	ev.syncSession();
-	ev._send(['start', { objectMode: true, enableAcks: true }]);
+	ev._send(['start', { objectMode: true, enableAcks: true }], {
+		control: true,
+		objectMode: false,
+	});
 
 	// Pass socket errors through to emitter
 	socket.on('error', function (err) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -8,6 +8,7 @@ var SendEmitter = require('./send_emitter')
 
 function Client () {
 	SendEmitter.call(this);
+	this.corked = true;  // Start out corked for normal messages.
 
 	// Ref or unref socket?  When unref'd, it won't keep the event loop
 	// alive when everything else has quit.
@@ -22,6 +23,7 @@ function Client () {
 		this.objectMode = !!config.objectMode;
 		this.enableAcks = !!config.enableAcks;
 		this.ready = true;
+		this.corked = false;
 	});
 
 	// Log errors to console, if error logging is enabled

--- a/lib/client.js
+++ b/lib/client.js
@@ -173,7 +173,7 @@ function onConnection (err, socket) {
 	// then attempt to backoff and reconnect
 	socket.on('close', function () {
 		ev.ready = false;
-		ev.emit('disconnect');
+		ev.emit('uhura:local:disconnect');
 
 		if (ev._reconnect === false) {
 			return;
@@ -200,5 +200,5 @@ function onConnection (err, socket) {
 		ev.unref();
 	}
 
-	ev.emit('connect');
+	ev.emit('uhura:local:connect');
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -204,6 +204,4 @@ function onConnection (err, socket) {
 	} else {
 		ev.unref();
 	}
-
-	ev.emit('uhura:local:connect');
 }

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -33,12 +33,15 @@ function Connection (socket, server) {
 	});
 
 	// Save session whenever it changes
-	this.on('_set', function () {
+	this.on('uhura:local:_set', onset);
+	this.on('_set', onset);
+
+	function onset () {
 		this.session.resetMaxAge();
 		this.session.save(function (err) {
 			if (err) console.error(err.stack);
 		});
-	});
+	}
 }
 util.inherits(Connection, SendEmitter);
 module.exports = Connection;
@@ -66,7 +69,7 @@ Connection.prototype.start = function (config) {
 
 	this.set('sessionID', this.sessionID);
 	this.ready = true;
-	this.emit('connect');
+	this.emit('uhura:local:connect');
 	this.send('connect', allowedConfig(config));
 };
 
@@ -88,7 +91,7 @@ Connection.prototype.resume = function (id, config) {
 		ev.sessionStore.createSession(ev, session);
 		ev.syncSession();
 		ev.ready = true;
-		ev.emit('connect', true);
+		ev.emit('uhura:local:connect', true);
 		ev.send('connect', allowedConfig(config));
 	});
 };
@@ -98,7 +101,7 @@ Connection.prototype.resume = function (id, config) {
  */
 
 Connection.prototype.disconnect = function () {
-	this.emit('disconnect');
+	this.emit('uhura:local:disconnect');
 	this.ready && (this.ready = false);
 };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -70,7 +70,7 @@ Connection.prototype.start = function (config) {
 	this.set('sessionID', this.sessionID);
 	this.ready = true;
 	this.emit('uhura:local:connect');
-	this.send('connect', allowedConfig(config));
+	this._send(['connect', allowedConfig(config)], { control: true });
 };
 
 /**
@@ -92,7 +92,7 @@ Connection.prototype.resume = function (id, config) {
 		ev.syncSession();
 		ev.ready = true;
 		ev.emit('uhura:local:connect', true);
-		ev.send('connect', allowedConfig(config));
+		ev._send(['connect', allowedConfig(config)], { control: true });
 	});
 };
 
@@ -112,6 +112,6 @@ Connection.prototype.disconnect = function () {
 Connection.prototype.invalidateSession = function () {
 	var ev = this;
 	this.sessionStore.destroy(this.session.sessionID, function (err) {
-		ev.send('invalidateSession');
+		ev._send(['invalidateSession'], { control: true });
 	});
 };

--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -57,7 +57,10 @@ module.exports = SendEmitter;
 
 SendEmitter.prototype.set = function (key, val) {
 	this.emit('uhura:local:_set', key, val);
-	this._send(['_set', key, val]);
+	this._send(['_set', key, val], {
+		control: true,
+		enableAcks: false,  // Suspect but backwards compatible.
+	});
 };
 
 /**
@@ -75,7 +78,10 @@ SendEmitter.prototype.get = function (key) {
  */
 
 SendEmitter.prototype.syncSession = function () {
-	this._send(['_set', this.session]);
+	this._send(['_set', this.session], {
+		control: true,
+		enableAcks: false,  // Suspect but backwards compatible.
+	});
 };
 
 /**
@@ -117,7 +123,8 @@ SendEmitter.prototype.attach = function (stream) {
 
 		// Send acks on messages that are, themselves, not acks
 		if (ev.enableAcks && args.id) {
-			ev._send({ args: ['ack::' + args.id] });
+			var ack = { args: ['ack::' + args.id] };
+			ev._send(ack, { control: true, enableAcks: false });
 		}
 
 		ev.emit.apply(ev, args.args);
@@ -138,17 +145,22 @@ SendEmitter.prototype.attach = function (stream) {
 	}
 };
 
-/**
- * Queue event to be sent to the server
- *
- * @param {string} [eventName] [Name of event to emit on the server]
- * @param {mixed}  [...]       [All following arguments are passed to receiver]
- */
-
 SendEmitter.prototype.send = function () {
-	var args = Array.prototype.slice.call(arguments);
+	return this._send([].slice.call(arguments));
+}
+
+SendEmitter.prototype._send = function (args, options) {
 	var ev = this;
-	
+
+	options = options || {};
+	options = Object.keys(options).reduce(function (acc, key) {
+		return acc[key] = options[key], acc;
+	}, {
+		control: false,
+		enableAcks: ev.enableAcks,
+		objectMode: ev.objectMode,
+	});
+
 	// Pop the last argument off of the argument list to act as the callback
 	// NOTE: Do this here to ensure ACK callbacks get ignored by old servers
 	var cb = (typeof args[args.length - 1] === 'function')
@@ -180,46 +192,24 @@ SendEmitter.prototype.send = function () {
 		return data;
 	}
 
-	// Ready to send data, determine how
-	function sendNow () {
-		// Attempt to send data in object mode,
-		// adding ack functionality, if enabled
-		if (ev.objectMode) {
-			var data = { args: args };
-			if (ev.enableAcks) {
-				data = withAck(data);
-				ev._send(data);
-				return;
-			}
-
-			ev._send(data);
-			cb();
-			return;
+	var data = args;
+	if (options.objectMode) {
+		data = { args: args };
+		if (options.control) {
+			data.control = true;
 		}
+		if (options.enableAcks) {
+			data = withAck(data);
+		}
+	}
 
-		ev._send(args);
+	if (ev.serializer) {
+		ev.serializer.write(data);
 		cb();
-	}
-
-	// Determine if we should send immediately, or queue for later
-	if (ev.ready) {
-		sendNow();
 	} else {
-		ev.queue.push(sendNow);
-	}
-};
-
-/**
- * Explicitly send data, regardless of ready state
- *
- * @param {string} [eventName] [Name of event to emit on the server]
- * @param {mixed}  [...]       [All following arguments are passed to receiver]
- */
-
-SendEmitter.prototype._send = function (data) {
-	if (this.serializer) {
-		this.serializer.write(data);
-	} else {
-		this.queue.push(this._send.bind(this, data));
+		ev.queue.push(function () {
+			ev.serializer.write(data);
+			cb();
+		});
 	}
 };

--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -11,7 +11,10 @@ function SendEmitter () {
 	events.EventEmitter.call(this);
 
 	// Create queue
-	this.queue = [];
+	this.queues = {
+		control: [],
+		payload: [],
+	};
 
 	// Handle ready state
 	var ready = false;
@@ -19,9 +22,8 @@ function SendEmitter () {
 	this.__defineSetter__('ready', function (v) {
 		ready = v;
 		if (ready) {
-			while (this.queue.length > 0) {
-				this.queue.shift()();
-			}
+			dequeue(this.queues.control);
+			dequeue(this.queues.payload);
 		}
 	});
 	this.__defineGetter__('ready', function () {
@@ -140,9 +142,8 @@ SendEmitter.prototype.attach = function (stream) {
 	this.serializer.pipe(stream).pipe(this.parser);
 
 	// Dequeue pending actions.
-	while (this.queue.length > 0) {
-		this.queue.shift()();
-	}
+	dequeue(this.queues.control);
+	dequeue(this.queues.payload);
 };
 
 SendEmitter.prototype.send = function () {
@@ -161,6 +162,8 @@ SendEmitter.prototype._send = function (args, options) {
 		objectMode: ev.objectMode,
 	});
 
+	var queue = options.control ? ev.queues.control : ev.queues.payload;
+
 	// Pop the last argument off of the argument list to act as the callback
 	// NOTE: Do this here to ensure ACK callbacks get ignored by old servers
 	var cb = (typeof args[args.length - 1] === 'function')
@@ -171,7 +174,7 @@ SendEmitter.prototype._send = function (args, options) {
 		// In the event of a message not being acknowledged,
 		// we should requeue the message with modified ACK id.
 		function requeue () {
-			ev.queue.push(ev._send.bind(ev, data));
+			queue.push(ev._send.bind(ev, data));
 		}
 
 		// Create ack listener and add id to data object
@@ -207,9 +210,19 @@ SendEmitter.prototype._send = function (args, options) {
 		ev.serializer.write(data);
 		cb();
 	} else {
-		ev.queue.push(function () {
+		queue.push(function () {
 			ev.serializer.write(data);
 			cb();
 		});
 	}
 };
+
+function dequeue (queue) {
+	// Make a copy and clear the original.  If we'd operate on the original
+	// and something pushes itself back onto the queue, that will result in
+	// an infinite loop.
+	var copy = queue.splice(0, queue.length);
+	while (copy.length > 0) {
+		copy.shift()();
+	}
+}

--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -12,7 +12,6 @@ function SendEmitter () {
 
 	// Create queue
 	this.queue = [];
-	this.maxQueueLength = Infinity;
 
 	// Handle ready state
 	var ready = false;
@@ -155,9 +154,7 @@ SendEmitter.prototype.send = function () {
 		// In the event of a message not being acknowledged,
 		// we should requeue the message with modified ACK id.
 		function requeue () {
-			queue(function () {
-				ev._send(data);
-			});
+			ev.queue.push(ev._send.bind(ev, data));
 		}
 
 		// Create ack listener and add id to data object
@@ -199,18 +196,12 @@ SendEmitter.prototype.send = function () {
 		cb();
 	}
 
-	// Add something to the callback queue
-	// Warn if the queue length gets too large
-	function queue (cb) {
-		if (ev.queue.length > ev.maxQueueLength) {
-			console.warn('Uhura exceeded maximum queue length, released stale data');
-			ev.queue.shift();
-		}
-		ev.queue.push(cb);
-	}
-
 	// Determine if we should send immediately, or queue for later
-	this.ready ? sendNow() : queue(sendNow);
+	if (ev.ready) {
+		sendNow();
+	} else {
+		ev.queue.push(sendNow);
+	}
 };
 
 /**

--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -129,7 +129,7 @@ SendEmitter.prototype.attach = function (stream) {
 
 	// Dequeue pending actions.
 	while (this.queue.length > 0) {
-		this.queue.unshift()();
+		this.queue.shift()();
 	}
 };
 

--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -10,20 +10,35 @@ var events = require('events')
 function SendEmitter () {
 	events.EventEmitter.call(this);
 
-	// Create queue
+	// Create send/recv queues.  Used when there is no connection (send) or
+	// when the connection handshake is still in progress (receive but only
+	// for normal messages, control messages are immediately emitted.)
 	this.queues = {
-		control: [],
-		payload: [],
+		control: [],  // Send queue only
+		payload: [],  // Send and receive queue
 	};
+
+	var corked = false;
+	this.__defineGetter__('corked', function () {
+		return corked;
+	});
+	this.__defineSetter__('corked', function (v) {
+		corked = !!v;
+		if (corked === false) {
+			dequeue(this.queues.payload);
+		}
+	});
 
 	// Handle ready state
 	var ready = false;
 	// FIXME(bnoordhuis) Setter with far ranging side effects, questionable.
 	this.__defineSetter__('ready', function (v) {
-		ready = v;
+		ready = !!v;
 		if (ready) {
 			dequeue(this.queues.control);
-			dequeue(this.queues.payload);
+			if (corked === false) {
+				dequeue(this.queues.payload);
+			}
 		}
 	});
 	this.__defineGetter__('ready', function () {
@@ -129,7 +144,12 @@ SendEmitter.prototype.attach = function (stream) {
 			ev._send(ack, { control: true, enableAcks: false });
 		}
 
-		ev.emit.apply(ev, args.args);
+		if (ev.corked && !args.control) {
+			var thunk = ev.emit.apply.bind(ev.emit, ev, args.args);
+			ev.queues.payload.push(thunk);
+		} else {
+			ev.emit.apply(ev, args.args);
+		}
 	});
 
 	// Propagate parse errors to the SendEmitter object
@@ -143,7 +163,9 @@ SendEmitter.prototype.attach = function (stream) {
 
 	// Dequeue pending actions.
 	dequeue(this.queues.control);
-	dequeue(this.queues.payload);
+	if (this.corked === false) {
+		dequeue(this.queues.payload);
+	}
 };
 
 SendEmitter.prototype.send = function () {

--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -38,6 +38,11 @@ function SendEmitter () {
 
 	// Handle shared session store data
 	this.session = {};
+
+	// For backwards compatibility with older clients we can't rename
+	// the '_set' event but at least we can give the local version a
+	// different name so it's possible to discern between the two.
+	this.on('uhura:local:_set', this._set);
 	this.on('_set', this._set);
 }
 util.inherits(SendEmitter, events.EventEmitter);
@@ -51,7 +56,7 @@ module.exports = SendEmitter;
  */
 
 SendEmitter.prototype.set = function (key, val) {
-	this.emit('_set', key, val);
+	this.emit('uhura:local:_set', key, val);
 	this._send(['_set', key, val]);
 };
 
@@ -164,13 +169,13 @@ SendEmitter.prototype.send = function () {
 		// When the correct ACK event is received,
 		// resolve and detach disconnect event
 		ev.once('ack::' + ack.id, function () {
-			ev.removeListener('disconnect', requeue);
+			ev.removeListener('uhura:local:disconnect', requeue);
 			ev.acks.resolve(ack.id);
 		});
 
 		// Trigger a requeue event if the connection is lost. This ensures
 		// that the message is moved to the ACK queue for the new connection.
-		ev.once('disconnect', requeue);
+		ev.once('uhura:local:disconnect', requeue);
 
 		return data;
 	}

--- a/lib/send_emitter.js
+++ b/lib/send_emitter.js
@@ -10,23 +10,24 @@ var events = require('events')
 function SendEmitter () {
 	events.EventEmitter.call(this);
 
+	// Create queue
+	this.queue = [];
+	this.maxQueueLength = Infinity;
+
 	// Handle ready state
 	var ready = false;
-	this.buffer = [];
+	// FIXME(bnoordhuis) Setter with far ranging side effects, questionable.
 	this.__defineSetter__('ready', function (v) {
-		var step;
 		ready = v;
 		if (ready) {
-			while (step = this.buffer.shift()) step();
+			while (this.queue.length > 0) {
+				this.queue.shift()();
+			}
 		}
 	});
 	this.__defineGetter__('ready', function () {
 		return ready;
 	});
-
-	// Create queue
-	this.queue = [];
-	this.maxQueueLength = Infinity;
 
 	// Object-mode is disabled by default, for backwards-compatibility
 	// Old versions of uhura expect array-formatted messages
@@ -201,11 +202,11 @@ SendEmitter.prototype.send = function () {
 	// Add something to the callback queue
 	// Warn if the queue length gets too large
 	function queue (cb) {
-		if (ev.buffer.length > ev.maxQueueLength) {
+		if (ev.queue.length > ev.maxQueueLength) {
 			console.warn('Uhura exceeded maximum queue length, released stale data');
-			ev.buffer.shift();
+			ev.queue.shift();
 		}
-		ev.buffer.push(cb);
+		ev.queue.push(cb);
 	}
 
 	// Determine if we should send immediately, or queue for later

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,7 @@ Server.prototype.start = function (options, cb) {
 	var createServer = options.createServer || net.createServer;
 	return createServer(options, function (socket) {
 		var con = new Connection(socket, server);
-		con.once('connect', function (reconnect) {
+		con.once('uhura:local:connect', function (reconnect) {
 			cb(con, reconnect);
 		});
 	});

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,8 +34,10 @@ Server.prototype.start = function (options, cb) {
 	var createServer = options.createServer || net.createServer;
 	return createServer(options, function (socket) {
 		var con = new Connection(socket, server);
+		con.corked = true;
 		con.once('uhura:local:connect', function (reconnect) {
 			cb(con, reconnect);
+			con.corked = false;
 		});
 	});
 };

--- a/test/basics.js
+++ b/test/basics.js
@@ -45,8 +45,8 @@ describe('basics', function () {
 		c.send('ping');
 	});
 
-	it('should emit disconnect on socket.destroy()', function (next) {
-		c.once('disconnect', next);
+	it('should emit uhura:local:disconnect on socket.destroy()', function (next) {
+		c.once('uhura:local:disconnect', next);
 		s.socket.destroy();
 	});
 

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -94,7 +94,7 @@ describe('reconnection', function () {
 			setTimeout(function () {
 				s.socket.destroy();
 				done();
-			}, 250);
+			}, 100);
 
 			// Push received pings to list
 			s.on('ping', function (v) {
@@ -114,7 +114,7 @@ describe('reconnection', function () {
 				c.send('ping', index);
 				sent.push(index);
 				index += 1;
-			}, 100);
+			}, 33);
 
 			c.autoReconnect();
 		});

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -115,7 +115,7 @@ describe('reconnection', function () {
 				sent.push(num);
 			}, 100);
 
-			c.on('connect', after(3, function () {
+			c.on('uhura:local:connect', after(3, function () {
 				clearInterval(timer);
 			}));
 

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -109,10 +109,11 @@ describe('reconnection', function () {
 			});
 
 			// Send messages repeatedly
+			var index = 0;
 			var timer = setInterval(function () {
-				var num = Math.floor(Math.random() * 1000);
-				c.send('ping', num);
-				sent.push(num);
+				c.send('ping', index);
+				sent.push(index);
+				index += 1;
 			}, 100);
 
 			c.on('uhura:local:connect', after(3, function () {

--- a/test/reconnect.js
+++ b/test/reconnect.js
@@ -116,10 +116,6 @@ describe('reconnection', function () {
 				index += 1;
 			}, 100);
 
-			c.on('uhura:local:connect', after(3, function () {
-				clearInterval(timer);
-			}));
-
 			c.autoReconnect();
 		});
 	});

--- a/test/session.js
+++ b/test/session.js
@@ -82,7 +82,7 @@ describe('session', function () {
 			c.on('connect', function () {
 				c.set('foo', 'bar');
 			});
-			c.on('disconnect', next);
+			c.on('uhura:local:disconnect', next);
 		});
 	});
 


### PR DESCRIPTION
This is mostly complete and passes almost all uhura tests (see below) and all strong-agent tests.

I'm not entirely happy with the magic 'corked' property but I copied the concept from the 'ready' property.  Both are setters that perform all kinds of side effects.

I'm still investigating the occasional failures of the 'should not lose messages while disconnected' test.  It worked by accident before but 3475fff exposed a race condition.

There is at least one bug in the test itself - it's possible for the timer to expire between the last message being sent and received - but it sometimes misses an older message whereas a newer one _has_ been received.  Could indicate that there is more than one way for #11 to happen.

Suggested reviewers: @sam-github @themitchy
