### PR TITLE
Switch from connect session middleware to using express-session directly

### DIFF
--- a/lib/session.js
+++ b/lib/session.js
@@ -2,10 +2,10 @@
  * Hijack connect session so I don't need to build my own session store
  */
 
-var Session = require('connect/lib/middleware/session/session')
-	, MemoryStore = require('connect/lib/middleware/session/memory')
-	, Cookie = require('connect/lib/middleware/session/cookie')
-	, Store = require('connect/lib/middleware/session/store')
+var Session = require('express-session/session/session')
+	, MemoryStore = require('express-session/session/memory')
+	, Cookie = require('express-session/session/cookie')
+	, Store = require('express-session/session/store')
 	, uid = require('uid2');
 
 /**

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
   "license": "MIT",
   "dependencies": {
     "JSONStream": "0.6.x",
-    "connect": "2.8.x",
     "uid2": "0.0.x",
-    "node-uuid": "~1.4.1"
+    "node-uuid": "~1.4.1",
+    "express-session": "~1.0.2"
   },
   "devDependencies": {
     "should": "~3.1.2",


### PR DESCRIPTION
With connect 3 and express 4, they were nice enough to finally split out the middleware. I removed the dependency on connect and switched to using express-session directly. This should make the dependency tree a little cleaner.
